### PR TITLE
Handling of active mod "quality"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+.gitignore export-ignore
+.gitattributes export-ignore
+
+* text=auto
+* text eol=lf
+
+*.png binary
+*.jpg binary
+*.ogg binary

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,10 @@
+---------------------------------------------------------------------------------------------------
+Version: 2.0.1
+Date: 27-03-2025
+  Changes:
+    - added script for easy building of release packages, just run ./scripts/build_package.py
+    - added support for quality mod (optional)
+    - set minimum version for "base"
+    - added this changelog.txt (add older versions below this record, newer above)
+    - added .gitattributes
+--------------------------------------------------------------------------------------------------

--- a/control.lua
+++ b/control.lua
@@ -5,7 +5,7 @@ local function signal_value(signal, value)
   value = math.min(math.max(value, -0x80000000), 0x7fffffff)
 
   local quality = "normal"
-  if mods["quality"] then
+  if script.active_mods["quality"] then
       quality = signal.quality
   end
 

--- a/control.lua
+++ b/control.lua
@@ -3,11 +3,17 @@
 ---@return LogisticFilter
 local function signal_value(signal, value)
   value = math.min(math.max(value, -0x80000000), 0x7fffffff)
+
+  local quality = "normal"
+  if mods["quality"] then
+      quality = signal.quality
+  end
+
   return {
     value = {
       type = signal.type or "item",
       name = signal.name,
-      quality = signal.quality or "normal",
+      quality = quality,
       comparator = "=",
     },
     min = value,
@@ -29,7 +35,7 @@ local function write_control(target, filters)
 
   --TODO: check/force exactly one unnamed section
   control.enabled = true
-  control.sections[1].filters=filters or {}
+  control.sections[1].filters = filters or {}
   return true
 end
 

--- a/control.lua
+++ b/control.lua
@@ -2,8 +2,6 @@
 ---@param value int32
 ---@return LogisticFilter
 local function signal_value(signal, value)
-  value = math.min(math.max(value, -0x80000000), 0x7fffffff)
-
   local quality = "normal"
   if script.active_mods["quality"] then
       quality = signal.quality
@@ -11,12 +9,12 @@ local function signal_value(signal, value)
 
   return {
     value = {
-      type = signal.type or "item",
-      name = signal.name,
-      quality = quality,
+      type       = signal.type or "item",
+      name       = signal.name,
+      quality    = quality,
       comparator = "=",
     },
-    min = value,
+    min = math.min(math.max(value, -0x80000000), 0x7fffffff),
   }
 end
 

--- a/control.lua
+++ b/control.lua
@@ -3,7 +3,7 @@
 ---@return LogisticFilter
 local function signal_value(signal, value)
   local quality = "normal"
-  if script.active_mods["quality"] then
+  if script.active_mods["quality"] and signal.quality then
       quality = signal.quality
   end
 

--- a/info.json
+++ b/info.json
@@ -7,7 +7,10 @@
   "homepage": "",
   "contact": "justarandomgeek@gmail.com",
   "description": "A set of general utility combinators. Includes: Location Combinators, Bonus Combinators, Research Combinators",
-  "dependencies": ["base"],
+  "dependencies": [
+    "base >= 2.0.42",
+    "?quality"
+  ],
   "package": {
     "sync_portal_details": true
   }

--- a/locale/de/de.cfg
+++ b/locale/de/de.cfg
@@ -1,0 +1,11 @@
+[entity-name]
+bonus-combinator=Kombinator für Bonuswerte
+location-combinator=Kombinator für Position
+player-combinator=Kombinator für Spieler
+research-combinator=Kombinator für Forschung
+
+[item-name]
+bonus-combinator=Kombinator für Bonuswerte
+location-combinator=Kombinator für Position
+player-combinator=Kombinator für Spieler
+research-combinator=Kombinator für Forschung

--- a/scripts/build_package.py
+++ b/scripts/build_package.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+import zipfile
+
+zip_suffix = 'zip'
+
+if __name__ == '__main__':
+    with open("info.json") as fin:
+        info_json = json.load(fin)
+        version = info_json['version']
+        zip_prefix = info_json['name']
+
+    version_name = zip_prefix + "_" + version
+    zipname = version_name + '.' + zip_suffix
+    print("Building %s" % zipname)
+    with zipfile.ZipFile(zipname, 'w', zipfile.ZIP_DEFLATED) as zout:
+        for root, dirs, files in os.walk('.'):
+            if '.git' in dirs:
+                dirs.remove('.git')
+            for f in files:
+                if re.match(zip_prefix + '.*' + zip_suffix, f):
+                    continue
+                if f.endswith("~"):
+                    continue
+                fullname = os.path.join(root, f)
+                newname = os.path.normpath(os.path.join(version_name, root, f))
+                print("%s -> %s" % (fullname, newname))
+                zout.write(fullname, arcname=newname)
+


### PR DESCRIPTION
Changes this PR includes:
- added script for easy building of release packages, just run ./scripts/build_package.py
- added support for quality mod (optional)
- set minimum version for "base"
- added this changelog.txt (add older versions below this record, newer above)
- added .gitattributes

Please note that I currently don't know how to implement that the combinator sets all qualities, not just normal. Higher quality science packs have longer duration during consumption.